### PR TITLE
Fixed compile error - missing pure virtual function on CDasherControl

### DIFF
--- a/Src/Gtk2/DasherControl.cpp
+++ b/Src/Gtk2/DasherControl.cpp
@@ -152,6 +152,12 @@ std::string CDasherControl::GetAllContext() {
   return text;
 }
 
+int CDasherControl::GetAllContextLenght()
+{
+  const gchar *text = gtk_dasher_control_get_all_text(m_pDasherControl);
+  return g_utf8_strlen(text,-1);
+}
+
 std::string CDasherControl::GetContext(unsigned int iStart, unsigned int iLength) {
   const gchar *text = gtk_dasher_control_get_context(m_pDasherControl, iStart, iLength);
   return text;

--- a/Src/Gtk2/DasherControl.h
+++ b/Src/Gtk2/DasherControl.h
@@ -138,6 +138,7 @@ public:
 
   virtual void ClearAllContext();
   virtual std::string GetAllContext();
+  virtual int GetAllContextLenght();
   std::string GetContext(unsigned int iStart, unsigned int iLength);
 
   virtual bool SupportsClipboard();


### PR DESCRIPTION
GetAllContextLength. The text in the buffer is UTF-8 so use g_utf8_strlen(..) on the text.