### PR TITLE
Require libatspi>=2.11 to avoid const conversion errors (#24)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -329,7 +329,7 @@ AC_CHECK_LIB(expat, XML_Parse,,[
 ])
 
 PKG_CHECK_MODULES([ATSPI],
-	[atspi-2],
+	[atspi-2 >= 2.11],
 	[have_libatspi=yes],
 	[have_libatspi=no])
 


### PR DESCRIPTION
Note: This means when building with an older version of libatspi present, it will be silently ignored instead of complaining that your libatspi is too old. I think that's the behavior we want since it seems to support building and running without libatspi, but let me know if not.

Resolves #24.