### PR TITLE
Linux Speak will use voice with language of current alphabet.

### DIFF
--- a/Src/Gtk2/DasherControl.cpp
+++ b/Src/Gtk2/DasherControl.cpp
@@ -180,7 +180,8 @@ bool CDasherControl::SupportsSpeech() {
 }
 
 void CDasherControl::Speak(const std::string &strText, bool bInterrupt) {
-  m_Speech.Speak(strText, bInterrupt);
+  string lang = GetActiveAlphabet()->GetLanguageCode();
+  m_Speech.Speak(strText, bInterrupt, lang);
 }
 #endif
 

--- a/Src/Gtk2/Speech.h
+++ b/Src/Gtk2/Speech.h
@@ -15,7 +15,7 @@ public:
   CSpeech();
   ~CSpeech();
   bool Init();
-  void Speak(const std::string &strText, bool bInterrupt);
+  void Speak(const std::string &strText, bool bInterrupt, const std::string &lang);
 private:
 #ifdef HAVE_SPEECHD
   SPDConnection *m_speaker;

--- a/Src/Gtk2/SpeechDispatcher.cpp
+++ b/Src/Gtk2/SpeechDispatcher.cpp
@@ -21,11 +21,17 @@ bool CSpeech::Init() {
 	return m_speaker != NULL;
 }
 
-void CSpeech::Speak(const std::string &strText, bool bInterrupt) {
+void CSpeech::Speak(const std::string &strText, bool bInterrupt, const std::string &lang) {
 	if (!Init()) {
 		return;
 	}
 	if (!bInterrupt) {
+		if (!lang.empty()) {
+			// Speechd only accepts 2-letter language codes and
+			// silently ignores anything else.
+			std::string shortLang = lang.substr(0, 2);
+			spd_set_language(m_speaker, shortLang.c_str());
+		}
 		if (!strText.empty()) {
 			spd_say(m_speaker, SPD_TEXT, strText.c_str());
 		}


### PR DESCRIPTION
Fixes #31.

Note: Speechd language setting is persistent and global. Selecting an alphabet with no langcode currently uses most recent langcode instead of user default.