### PR TITLE
Fix startup warnings and some Gtk3 deprecation warnings on Linux

### DIFF
--- a/Src/Gtk2/GtkDasherControl.cpp
+++ b/Src/Gtk2/GtkDasherControl.cpp
@@ -50,8 +50,12 @@ enum {
 
 #define GTK_DASHER_CONTROL_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE((o), GTK_DASHER_TYPE_CONTROL, GtkDasherControlPrivate));
 
-/* TODO: is it still sensible to derive from VBox, given that its just a cnavas now*/
+/* TODO: is it still sensible to derive from Box, given that its just a canvas now*/
+#if GTK_CHECK_VERSION (3,0,0)
+G_DEFINE_TYPE(GtkDasherControl, gtk_dasher_control, GTK_TYPE_BOX);
+#else
 G_DEFINE_TYPE(GtkDasherControl, gtk_dasher_control, GTK_TYPE_VBOX);
+#endif
 
 static void gtk_dasher_control_finalize(GObject * pObject);
 
@@ -228,6 +232,9 @@ gtk_dasher_control_get_context(GtkDasherControl *pControl, unsigned int iStart, 
 std::string
 gtk_dasher_control_get_all_text(GtkDasherControl *pControl) {
   GtkDasherControlPrivate *pPrivate = GTK_DASHER_CONTROL_GET_PRIVATE(pControl);
+  if (pPrivate->pEditor == NULL) {
+    return "";
+  }
   return dasher_editor_get_all_text(pPrivate->pEditor);
 }
 

--- a/Src/Gtk2/dasher_editor.cpp
+++ b/Src/Gtk2/dasher_editor.cpp
@@ -17,7 +17,11 @@
 #include "GtkDasherControl.h"
 #include "../DasherCore/ControlManager.h"
 
+#if GTK_CHECK_VERSION (3,0,0)
+G_DEFINE_TYPE(DasherEditor, dasher_editor, GTK_TYPE_BOX);
+#else
 G_DEFINE_TYPE(DasherEditor, dasher_editor, GTK_TYPE_VBOX);
+#endif
 
 /* Signals */
 enum {
@@ -197,8 +201,13 @@ dasher_editor_finalize(GObject *pObject) {
 DasherEditor*
 dasher_editor_new(void)
 {
+#if GTK_CHECK_VERSION (3,0,0)
+  return
+    DASHER_EDITOR(g_object_new(DASHER_TYPE_EDITOR, "orientation", GTK_ORIENTATION_VERTICAL, NULL));
+#else
   return
     DASHER_EDITOR(g_object_new(DASHER_TYPE_EDITOR, NULL));
+#endif
 }
 
 void
@@ -709,7 +718,7 @@ dasher_editor_internal_handle_font(DasherEditor *pSelf, const gchar *szFont) {
     DasherEditorPrivate *pPrivate = DASHER_EDITOR_GET_PRIVATE(pSelf);
 
     PangoFontDescription *pFD = pango_font_description_from_string(szFont);
-    gtk_widget_modify_font(GTK_WIDGET(pPrivate->pTextView), pFD);
+    gtk_widget_override_font(GTK_WIDGET(pPrivate->pTextView), pFD);
   }
 }
 
@@ -806,9 +815,9 @@ dasher_editor_internal_command_open(DasherEditor *pSelf) {
   GtkWidget *filesel = gtk_file_chooser_dialog_new(_("Select File"),
 						   GTK_WINDOW(pTopLevel),
 						   GTK_FILE_CHOOSER_ACTION_OPEN,
-						   GTK_STOCK_OPEN,
+						   _("_Open"),
 						   GTK_RESPONSE_ACCEPT,
-						   GTK_STOCK_CANCEL,
+						   _("_Cancel"),
 						   GTK_RESPONSE_CANCEL, NULL);
 
 #ifdef HAVE_GIO
@@ -840,9 +849,9 @@ dasher_editor_internal_command_save(DasherEditor *pSelf, gboolean bPrompt, gbool
     GtkWidget *filesel = gtk_file_chooser_dialog_new(_("Select File"),
 						     GTK_WINDOW(pTopLevel),
 						     GTK_FILE_CHOOSER_ACTION_SAVE,
-						     GTK_STOCK_SAVE,
+						     _("_Save"),
 						     GTK_RESPONSE_ACCEPT,
-						     GTK_STOCK_CANCEL,
+						     _("_Cancel"),
 						     GTK_RESPONSE_CANCEL, NULL);
 
 #ifdef HAVE_GIO

--- a/Src/Gtk2/dasher_main.cpp
+++ b/Src/Gtk2/dasher_main.cpp
@@ -523,8 +523,8 @@ void show_game_file_dialog(GtkWidget *pButton, GtkWidget *pWidget, gpointer pDat
 	GtkWidget *pFileDialog = gtk_file_chooser_dialog_new("Choose a Game Text",
 				      GTK_WINDOW(objRefs->first),
 				      GTK_FILE_CHOOSER_ACTION_OPEN,
-				      GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-				      GTK_STOCK_OPEN, GTK_RESPONSE_ACCEPT,
+				      _("_Cancel"), GTK_RESPONSE_CANCEL,
+				      _("_Open"), GTK_RESPONSE_ACCEPT,
 				      NULL);
 	
 	gtk_window_set_destroy_with_parent(GTK_WINDOW(pFileDialog), true);
@@ -612,8 +612,8 @@ void dasher_main_command_toggle_game_mode(DasherMain *pSelf) {
                                                 GTK_MESSAGE_OTHER, GTK_BUTTONS_NONE,
                                                 _("Are you sure you wish to turn off game mode? All unsaved changes will be lost."));
 
-    GtkWidget *pNoButton = gtk_dialog_add_button(GTK_DIALOG(pDialog), GTK_STOCK_NO, GTK_RESPONSE_REJECT);
-    GtkWidget *pYesButton = gtk_dialog_add_button(GTK_DIALOG(pDialog), GTK_STOCK_YES, GTK_RESPONSE_ACCEPT);
+    GtkWidget *pNoButton = gtk_dialog_add_button(GTK_DIALOG(pDialog), _("No"), GTK_RESPONSE_REJECT);
+    GtkWidget *pYesButton = gtk_dialog_add_button(GTK_DIALOG(pDialog), _("Yes"), GTK_RESPONSE_ACCEPT);
 
     if(gtk_dialog_run(GTK_DIALOG(pDialog))==GTK_RESPONSE_ACCEPT) {
       gtk_dasher_control_set_game_mode(GTK_DASHER_CONTROL(pPrivate->pDasherWidget), false);
@@ -880,8 +880,8 @@ dasher_main_command_import(DasherMain *pSelf) {
   GtkWidget *pFileSel = gtk_file_chooser_dialog_new(_("Select File"), 
                                                     GTK_WINDOW(pPrivate->pMainWindow), 
                                                     GTK_FILE_CHOOSER_ACTION_OPEN, 
-                                                    GTK_STOCK_OPEN, GTK_RESPONSE_ACCEPT, 
-                                                    GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL, 
+                                                    _("_Open"), GTK_RESPONSE_ACCEPT,
+                                                    _("_Cancel"), GTK_RESPONSE_CANCEL,
                                                     NULL);
 
 #ifdef TEACH_TRAINING_HELPER_LOAD_FILE_ABOUT_URI

--- a/Src/Gtk2/module_settings_window.cpp
+++ b/Src/Gtk2/module_settings_window.cpp
@@ -74,7 +74,7 @@ module_settings_window_init(ModuleSettingsWindow *pDasherControl) {
 
   pPrivateData->pFirst = NULL;
 
-  GtkWidget *pButton = gtk_dialog_add_button(&(pDasherControl->window), GTK_STOCK_CLOSE, GTK_RESPONSE_NONE);
+  GtkWidget *pButton = gtk_dialog_add_button(&(pDasherControl->window), _("_Close"), GTK_RESPONSE_NONE);
 
   g_signal_connect(G_OBJECT(pButton), "clicked", G_CALLBACK(handle_close), pDasherControl);
   g_signal_connect(G_OBJECT(&(pDasherControl->window)), "delete-event", G_CALLBACK(handle_close_event), pDasherControl);


### PR DESCRIPTION
1. Fixes junk output on startup like
```
(dasher:17150): GLib-GObject-CRITICAL **: g_type_instance_get_private: assertion 'instance != NULL && instance->g_class != NULL' failed
```
by handling null.
2. Cleans up a bunch of deprecation warnings when building with Gtk3.