### PR TITLE
Changed IsPointVisible to IsWindowUnderCursor. 

### DIFF
--- a/Src/DasherCore/CircleStartHandler.cpp
+++ b/Src/DasherCore/CircleStartHandler.cpp
@@ -82,7 +82,7 @@ void CCircleStartHandler::Timer(unsigned long iTime, dasherint mouseX, dasherint
   screenint x,y;
   pView->Dasher2Screen(mouseX, mouseY, x, y);
   int dx=x-ctr.x, dy=y-ctr.y;
-  const bool inCircleNow = dx*dx + dy*dy <= (m_iScreenRadius * m_iScreenRadius) && pView->Screen()->IsPointVisible(x,y);
+  const bool inCircleNow = dx*dx + dy*dy <= (m_iScreenRadius * m_iScreenRadius) && pView->Screen()->IsWindowUnderCursor();
 
   if (inCircleNow) {
     if (m_bInCircle) {

--- a/Src/DasherCore/DasherScreen.h
+++ b/Src/DasherCore/DasherScreen.h
@@ -170,8 +170,8 @@ public:
   /// \param pColourScheme A colour scheme that should be used
   virtual void SetColourScheme(const Dasher::CColourIO::ColourInfo *pColourScheme) = 0;
   
-  // Returns true if point on screen is not obscured by another window
-  virtual bool IsPointVisible(screenint x, screenint y) = 0;
+  // Returns true if cursor is over visible part of this window.
+  virtual bool IsWindowUnderCursor() = 0;
 
 private:
   //! Width and height of the screen

--- a/Src/DasherCore/TwoBoxStartHandler.cpp
+++ b/Src/DasherCore/TwoBoxStartHandler.cpp
@@ -44,7 +44,7 @@ void CTwoBoxStartHandler::Timer(unsigned long iTime, dasherint iDasherX, dasheri
 
   if ((iNewScreenY >= iBoxMin) && (iNewScreenY <= iBoxMax) 
 	  && (iNewScreenX >= 8) && (iNewScreenX <= pView->Screen()->GetWidth() - 16)
-	  && pView->Screen()->IsPointVisible(iNewScreenX, iNewScreenY)) {
+	  && pView->Screen()->IsWindowUnderCursor()) {
     if(m_iBoxEntered == std::numeric_limits<long>::max()) {
       m_iBoxEntered = iTime;
     }

--- a/Src/Gtk2/Canvas.cpp
+++ b/Src/Gtk2/Canvas.cpp
@@ -5,6 +5,7 @@
 
 #include "../DasherCore/DasherTypes.h"
 
+
 using namespace Dasher;
 
 CCanvas::CCanvas(GtkWidget *pCanvas)
@@ -99,6 +100,16 @@ void CCanvas::resize(screenint w,screenint h) {
   CDasherScreen::resize(w,h);
   InitSurfaces();
 } 
+
+bool CCanvas::IsWindowUnderCursor() {
+  GdkDisplay * gdkDisplay = gdk_display_get_default();
+  gint winx,winy;
+  // unfortunately under X we cannot arbritrarily find which window
+  // lives at a location. Only underneath the cursor.
+  GdkWindow * window = gdk_display_get_window_at_pointer(gdkDisplay, &winx, &winy);  
+  return window == gtk_widget_get_window(m_pCanvas);
+}
+
 
 void CCanvas::Display() {
   // FIXME - Some of this stuff is probably not needed

--- a/Src/Gtk2/Canvas.h
+++ b/Src/Gtk2/Canvas.h
@@ -179,8 +179,8 @@ public:
 
   // Redeclare to make public and adjust cairo/gdk surface sizes
   void resize(screenint w,screenint h);
-  // Returns true if point on screen is not obscured by another window
-  bool IsPointVisible(screenint x, screenint y) override { return true; }
+  // Returns true if cursor is over visible part of this window.
+  bool IsWindowUnderCursor() override;
 
 private:
 

--- a/Src/Win32/Widgets/Screen.cpp
+++ b/Src/Win32/Widgets/Screen.cpp
@@ -213,7 +213,6 @@ void CScreen::Polygon(point *Points, int Number, int fillColour, int outlineColo
 bool CScreen::IsWindowUnderCursor() {
   POINT pt;
   GetCursorPos(&pt);
-  ClientToScreen(m_hWnd, &pt);
   HWND h = WindowFromPoint(pt);
   return h == m_hWnd;
 }

--- a/Src/Win32/Widgets/Screen.cpp
+++ b/Src/Win32/Widgets/Screen.cpp
@@ -210,8 +210,9 @@ void CScreen::Polygon(point *Points, int Number, int fillColour, int outlineColo
 }
 
 /////////////////////////////////////////////////////////////////////////////
-bool CScreen::IsPointVisible(screenint x, screenint y) {
-  POINT pt = { x, y };
+bool CScreen::IsWindowUnderCursor() {
+  POINT pt;
+  GetCursorPos(&pt);
   ClientToScreen(m_hWnd, &pt);
   HWND h = WindowFromPoint(pt);
   return h == m_hWnd;

--- a/Src/Win32/Widgets/Screen.h
+++ b/Src/Win32/Widgets/Screen.h
@@ -75,8 +75,8 @@ public:
 
   void SendMarker(int iMarker) override;
 
-  // Returns true if point on screen is not obscured by another window
-  bool IsPointVisible(screenint x, screenint y) override;
+  // Returns true if cursor is over visible part of this window.
+  bool IsWindowUnderCursor() override;
 
   void RealDisplay(HDC hDC, RECT r);
   void resize(screenint w, screenint h);


### PR DESCRIPTION
This change was done because:

X11 doesn't appear to have a way to test for which window is visible at an
arbitrary point. We can only test using XQueryPointer (or it's GDK friends)
which window lives underneath the cursor.