### PR TITLE
Move langcode to attribute on "alphabets" element in XML

### DIFF
--- a/Data/alphabets/alphabet.Armenian.xml
+++ b/Data/alphabets/alphabet.Armenian.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="hy">
 <alphabet name="Armenian / &#1344;&#1377;&#1397;&#1381;&#1408;&#1381;&#1398; with punctuation and numerals">
 <!-- Alphabet by David MacKay and Kostas Savvidis -->
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_Armenian_AM.txt</train>
-<langcode>hy</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>
@@ -167,7 +166,6 @@
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_Armenian_AM.txt</train>
-<langcode>hy</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.Assamese.xml
+++ b/Data/alphabets/alphabet.Assamese.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet-nest.xsl"?>
-<alphabets>
+<alphabets langcode="as">
 <alphabet name="Assamese &#x0985;&#x09b8;&#x09ae;&#x09c0;&#x09af;&#x09bc;&#x09be;  with punctuation and numerals">
 <!-- See also alphabet.bengali.xml
  Bangla is the second most commonly spoken language in India.
@@ -11,7 +11,6 @@
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_Assamese_IN.txt</train>
-<langcode>as</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.Belarusian.xml
+++ b/Data/alphabets/alphabet.Belarusian.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="be">
 <alphabet name="Belarusian with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_Belarusian_BY.txt</train>
-<langcode>be</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.Bulgarian.xml
+++ b/Data/alphabets/alphabet.Bulgarian.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="bg">
 <alphabet name="Bulgarian / &#1041;&#1098;&#1083;&#1075;&#1072;&#1088;&#1089;&#1082;&#1072; &#1089; &#1087;&#1091;&#1085;&#1082;&#1090;&#1091;&#1072;&#1094;&#1080;&#1103; &#1080; &#1094;&#1080;&#1092;&#1088;&#1080;">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_Bulgarian_BG.txt</train>
-<langcode>bg</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.Estonian.xml
+++ b/Data/alphabets/alphabet.Estonian.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="et">
 <alphabet name="Eesti / Estonian with punctuation and numerals">
 <!-- Eestlane -->
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_Estonian_EE.txt</train>
-<langcode>et</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.Greek.xml
+++ b/Data/alphabets/alphabet.Greek.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="el">
 <alphabet name="Ellinika (&#917;&#955;&#955;&#951;&#957;&#953;&#954;&#940;) / Greek with punctuation and numerals">
 <!-- alphabet by Pantelis Nasikas and David MacKay with help from Mark Owen -->
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_greek_GR.txt</train>
-<langcode>el</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8" />
@@ -145,7 +144,6 @@
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_greek_GR.txt</train>
-<langcode>el</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8" />

--- a/Data/alphabets/alphabet.Gujarati.xml
+++ b/Data/alphabets/alphabet.Gujarati.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="gu">
 <alphabet name="Gujarati with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_Gujarati_IN.txt</train>
-<langcode>gu</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.Hindi.xml
+++ b/Data/alphabets/alphabet.Hindi.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet-nest.xsl"?>
-<alphabets>
+<alphabets langcode="hi">
 <alphabet name="Hindi / &#2361;&#2367;&#2306;&#2342;&#2368; ">
 <!-- see file:///home/mackay/dasher/alphabets/tmpH.html for queries -->
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_Hindi_IN.txt</train>
-<langcode>hi</langcode>
 <space d="&#x25a1;" t=" " b="9"/> 
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>
@@ -161,7 +160,6 @@
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_Hindi_IN.txt</train>
-<langcode>hi</langcode>
 <space d="&#x25a1;" t=" " b="9"/> 
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.Icelandic.xml
+++ b/Data/alphabets/alphabet.Icelandic.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="is">
 <alphabet name="Icelandic / &#x00CD;slensku with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_Icelandic_IS.txt</train>
-<langcode>is</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.IrishGaelic.xml
+++ b/Data/alphabets/alphabet.IrishGaelic.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="ga">
 <alphabet name="Gaeilge na h&#x00C9;ireann / Irish Gaelic with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <control d="Control" t=""/>
 <palette>Default</palette>
 <train>training_IrishGaelic_IE.txt</train>
-<langcode>ga</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <group name="lower case letters" b="0">

--- a/Data/alphabets/alphabet.Marathi.xml
+++ b/Data/alphabets/alphabet.Marathi.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="mr">
 <alphabet name="Marathi - Devanagari with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_Marathi_IN.txt</train>
-<langcode>mr</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t="" b="8"/>
 <paragraph d="&#182;" b="9"/>

--- a/Data/alphabets/alphabet.Oriya.xml
+++ b/Data/alphabets/alphabet.Oriya.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="or">
 <alphabet name="Oriya with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_Oriya_IN.txt</train>
-<langcode>or</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.Punjabi.xml
+++ b/Data/alphabets/alphabet.Punjabi.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="pa">
 <alphabet name="Punjabi (Gurmukhi) with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_Punjabi_IN.txt</train>
-<langcode>pa</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.Sami.xml
+++ b/Data/alphabets/alphabet.Sami.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="se">
 <alphabet name="Sami / Lappish with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_Sami_NO.txt</train>
-<langcode>se</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.ScotsGaelic.xml
+++ b/Data/alphabets/alphabet.ScotsGaelic.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="gd">
 <alphabet name="G&#x00E0;idhlig / Scots Gaelic with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <control d="Control" t=""/>
 <palette>Default</palette>
 <train>training_ScotsGaelic_GB.txt</train>
-<langcode>gd</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <group name="lower case letters" b="0">

--- a/Data/alphabets/alphabet.Sinhala.xml
+++ b/Data/alphabets/alphabet.Sinhala.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="si">
 <alphabet name="Sinhala with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_Sinhala_IN.txt</train>
-<langcode>si</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.Slovak.xml
+++ b/Data/alphabets/alphabet.Slovak.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="sk">
 <alphabet name="Slovensk&#x00FD; / Slovak with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_Slovak_SK.txt</train>
-<langcode>sk</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.Slovenian.xml
+++ b/Data/alphabets/alphabet.Slovenian.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="sl">
 <alphabet name="Sloven&#x0161;&#x010D;ina / Slovene with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_Slovenian_SI.txt</train>
-<langcode>sl</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.Tajik.xml
+++ b/Data/alphabets/alphabet.Tajik.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="tg">
 <alphabet name="Tajik with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Cyrillic"/>
 <control d="Control" t=""/>
 <palette>Default</palette>
 <train>training_Tajik_TJ.txt</train>
-<langcode>tg</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <group name="lower case letters" b="0">

--- a/Data/alphabets/alphabet.Turkish.xml
+++ b/Data/alphabets/alphabet.Turkish.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="tr">
 <alphabet name="T&#x00FC;rk&#x00E7;e / Turkish with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_turkish_TR.txt</train>
-<langcode>tr</langcode>
 <paragraph d="&#182;" b="9"/>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.Urdu.xml
+++ b/Data/alphabets/alphabet.Urdu.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet-nest.xsl"?>
-<alphabets>
+<alphabets langcode="ur">
 <alphabet name="Urdu with punctuation and numerals">
 <orientation type="RL"/>
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_Urdu_PK.txt</train>
-<langcode>ur</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.afrikaans.xml
+++ b/Data/alphabets/alphabet.afrikaans.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="af">
 <alphabet name="Afrikaans with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <control d="Control" t=""/>
 <palette>Default</palette>
 <train>training_Afrikaans_ZA.txt</train>
-<langcode>af</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <group name="lower case letters" b="0">

--- a/Data/alphabets/alphabet.albanian.xml
+++ b/Data/alphabets/alphabet.albanian.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="sq">
 <alphabet name="Shqip / Albanian with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_albanian_SQ.txt</train>
-<langcode>sq</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t="" b="8"/>
 <paragraph d="&#182;" b="9"/>

--- a/Data/alphabets/alphabet.bengali.xml
+++ b/Data/alphabets/alphabet.bengali.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet-nest.xsl"?>
-<alphabets>
+<alphabets langcode="bn">
 <alphabet name="Bengali / &#x09ac;&#x09be;&#x0982;&#x09b2;&#x09be;   with punctuation and numerals">
 <!--
  Bangla is the second most commonly spoken language in India.
@@ -42,7 +42,6 @@ http://prdownloads.sourceforge.net/lekho/dict_v1.15.tgz?download )
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_bengali_BD.txt</train>
-<langcode>bn</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.bosnian.xml
+++ b/Data/alphabets/alphabet.bosnian.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="bs">
 <alphabet name="Bosanski / Bosnian with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_bosnian_BA.txt</train>
-<langcode>bs</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.breton.xml
+++ b/Data/alphabets/alphabet.breton.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="br">
 <alphabet name="Ar brezhoneg / Breton with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_breton_FR.txt</train>
-<langcode>br</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.catalan.xml
+++ b/Data/alphabets/alphabet.catalan.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="ca">
 <alphabet name="Catal&#x00E0; / Catalan with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_catalan_ES.txt</train>
-<langcode>ca</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>
@@ -147,7 +146,6 @@
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_catalanC_ES.txt</train>
-<langcode>ca</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.corsican.xml
+++ b/Data/alphabets/alphabet.corsican.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="co">
 <alphabet name="Corsu / Corsican with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_corsican_FR.txt</train>
-<langcode>co</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.croatian.xml
+++ b/Data/alphabets/alphabet.croatian.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="hr">
 <alphabet name="Hrvatski / Croatian with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_croatian_HR.txt</train>
-<langcode>hr</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.czech.xml
+++ b/Data/alphabets/alphabet.czech.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="cs">
   <alphabet name="Czech / &#268;e&#353;tina">
     <orientation type="LR" />
     <encoding type="Western" />
 <palette>European/Asian</palette>
     <train>training_czech_CS.txt</train>
-    <langcode>cs</langcode>
 <paragraph d="&#182;" b="9"/>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t="" b="8"/>
@@ -162,7 +161,6 @@
     <encoding type="Western" />
 <palette>European/Asian</palette>
     <train>training_czechC_CS.txt</train>
-    <langcode>cs</langcode>
 <paragraph d="&#182;" b="9"/>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.danish.xml
+++ b/Data/alphabets/alphabet.danish.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="da">
 <alphabet name="Dansk / Danish with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_danish_DK.txt</train>
-<langcode>da</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>
@@ -148,7 +147,6 @@
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_danish_DK.txt</train>
-<langcode>da</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>
@@ -239,7 +237,6 @@
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_danish_DK.txt</train>
-<langcode>da</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.dtd
+++ b/Data/alphabets/alphabet.dtd
@@ -3,6 +3,7 @@ along with some useful information. It does nothing to tell Dasher,
 how those symbols may be used. -->
 
 <!ELEMENT alphabets (alphabet*)>
+<!ATTLIST alphabets langcode CDATA #IMPLIED>
 
 <!ELEMENT alphabet (orientation, encoding, palette, train, langcode?, paragraph,
 	space, control, conversionmode?, group*)>

--- a/Data/alphabets/alphabet.dutch.xml
+++ b/Data/alphabets/alphabet.dutch.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="nl">
 <alphabet name="Nederlands / Dutch with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_dutch_NL.txt</train>
-<langcode>nl</langcode>
 <space d="&#x25a1;" t=" " b="9"/>
 <control d="Control" t="" b="8"/>
 <paragraph d="&#182;" b="9"/>

--- a/Data/alphabets/alphabet.english.xml
+++ b/Data/alphabets/alphabet.english.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="en-GB">
 <alphabet name="English with limited punctuation">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_english_GB.txt</train>
-<langcode>en-GB</langcode>
 <paragraph d="&#182;" b="9"/>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t="" b="8"/>
@@ -86,7 +85,6 @@
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_english_GB.txt</train>
-<langcode>en-GB</langcode>
 <paragraph d="&#182;" b="9"/>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t="" b="8"/>
@@ -173,7 +171,6 @@
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_english_GB.txt</train>
-<langcode>en-GB</langcode>
 <space d="&#x25a1;" t=" "  b="9"/>
 <control d="Control" t=""/>
 <paragraph d="&#182;" b="9"/>
@@ -292,7 +289,6 @@
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_englishLC_GB.txt</train>
-<langcode>en-GB</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t="" b="8"/>
 <group name="Lower case Latin letters" b="0">

--- a/Data/alphabets/alphabet.englishC.xml
+++ b/Data/alphabets/alphabet.englishC.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="en-GB">
 <alphabet name="English with accents, numerals, punctuation">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_english_GB.txt</train>
-<langcode>en-GB</langcode>
 <space d="&#x25a1;" t=" "  b="9"/>
 <control d="Control" t=""  b="8"/>
 <paragraph d="&#182;" b="9"/>

--- a/Data/alphabets/alphabet.faroese.xml
+++ b/Data/alphabets/alphabet.faroese.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="fo">
 <alphabet name="F&#x00F8;royskt / Faroese with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_faroese_FO.txt</train>
-<langcode>fo</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.finnish.xml
+++ b/Data/alphabets/alphabet.finnish.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="fi">
 <alphabet name="Suomalainen / Finnish with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_finnish_FI.txt</train>
-<langcode>fi</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.finnish2.xml
+++ b/Data/alphabets/alphabet.finnish2.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="fi">
 <alphabet name="Suomalainen / Finnish with limited punctuation">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_finnish_FI.txt</train>
-<langcode>fi</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>
@@ -96,7 +95,6 @@
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_finnishL_FI.txt</train>
-<langcode>fi</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.french.xml
+++ b/Data/alphabets/alphabet.french.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet-nest.xsl"?>
-<alphabets>
+<alphabets langcode="fr">
 <alphabet name="Fran&#x00E7;ais / French with numerals and punctuation">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_french_FR.txt</train>
-<langcode>fr</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t="" b="8"/>
 <paragraph d="&#182;" b="9"/>
@@ -150,7 +149,6 @@
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_frenchC_FR.txt</train>
-<langcode>fr</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t=""/>
 <paragraph d="&#182;" b="9"/>
@@ -282,7 +280,6 @@
 <encoding type="Western"/>
 <palette>Vowels</palette>
 <train>training_french_FR.txt</train>
-<langcode>fr</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t="" b="8"/>
 <paragraph d="&#182;" b="9"/>

--- a/Data/alphabets/alphabet.galician.xml
+++ b/Data/alphabets/alphabet.galician.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="gl">
 <alphabet name="Galego / Galician with punctuation and numerals">
 <!--
 Galician is a Romance language spoken by about 3 million people in Galicia, in the north-west corner of Spain. Galician is more or less mutually intelligible with Portuguese.
@@ -10,7 +10,6 @@ Galician is a Romance language spoken by about 3 million people in Galicia, in t
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_galician_ES.txt</train>
-<langcode>gl</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.german.xml
+++ b/Data/alphabets/alphabet.german.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="de">
 <alphabet name="Deutsch / German with numerals and punctuation">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_german_DE.txt</train>
-<langcode>de</langcode>
 <paragraph d="&#182;" b="9"/>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t="" b="8" />
@@ -133,7 +132,6 @@
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_german_DE.txt</train>
-<langcode>de</langcode>
 <paragraph d="&#182;" b="9"/>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t="" b="8" />
@@ -213,7 +211,6 @@
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_germanL_DE.txt</train>
-<langcode>de</langcode>
 <paragraph d="&#182;" b="9"/>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t="" b="8" />

--- a/Data/alphabets/alphabet.hungarian.xml
+++ b/Data/alphabets/alphabet.hungarian.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="hu">
 <alphabet name="Magyar / Hungarian / nagybet&#369;ssel, r&#246;vid">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <train>training_hungarian_HU.txt</train>
-<langcode>hu</langcode>
 <paragraph d="&#182;" b="9"/>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t="" b="8"/>
@@ -135,7 +134,6 @@
 <orientation type="LR"/>
 <encoding type="Western"/>
 <train>training_hungarian_HU.txt</train>
-<langcode>hu</langcode>
 <paragraph d="&#182;" b="9"/>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.iso8859.xml
+++ b/Data/alphabets/alphabet.iso8859.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="fr">
 <alphabet name="Latin ISO-8859 (combining accents) with numerals and punctuation">
 <!--
 Any word that can be written using one of the Latin ISO-8859 character sets (ISO-8859-1,2,3,4,9,10,13,14,15,16) can be written, in decomposed form, using the ASCII characters, the 23 additional letters, and 14 modifiers
@@ -10,7 +10,6 @@ Any word that can be written using one of the Latin ISO-8859 character sets (ISO
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_frenchC_FR.txt</train>
-<langcode>fr</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t="" b="8"/>
 <paragraph d="&#182;" b="9"/>

--- a/Data/alphabets/alphabet.italian.xml
+++ b/Data/alphabets/alphabet.italian.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="it">
 <alphabet name="Italiano / Italian - limited punctuation">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <train>training_italian_IT.txt</train>
-<langcode>it</langcode>
 <paragraph d="&#182;" b="9"/>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t="" b="8"/>
@@ -106,7 +105,6 @@
 <orientation type="LR"/>
 <encoding type="Western"/>
 <train>training_italian_IT.txt</train>
-<langcode>it</langcode>
 <paragraph d="&#182;" b="9"/>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t="" b="8"/>
@@ -235,7 +233,6 @@
 <orientation type="LR"/>
 <encoding type="Western"/>
 <train>training_italianC_IT.txt</train>
-<langcode>it</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t=""/>
 <paragraph d="&#182;" b="9"/>

--- a/Data/alphabets/alphabet.kurdish.xml
+++ b/Data/alphabets/alphabet.kurdish.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="ku">
 <alphabet name="Kurd&#x00EE; / Kurdish with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_kurdish_IQ.txt</train>
-<langcode>ku</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.latin.xml
+++ b/Data/alphabets/alphabet.latin.xml
@@ -2,13 +2,12 @@
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
 <!-- Author: David J C MacKay 2005 -->
-<alphabets>
+<alphabets langcode="la">
 <alphabet name="Latin (classical) with numerals and punctuation">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_latin_XX.txt</train>
-<langcode>la</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t="" b="8"/>
 <paragraph d="&#182;" b="9"/>

--- a/Data/alphabets/alphabet.latvian.xml
+++ b/Data/alphabets/alphabet.latvian.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="lv">
 <alphabet name="Latvie&#353;u / Latvian with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_latvian_LV.txt</train>
-<langcode>lv</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.lithuanian.xml
+++ b/Data/alphabets/alphabet.lithuanian.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="lt">
 <alphabet name="Lietuvos / Lithuanian with punctuation and numerals">
 <!-- Lithuanian is a Baltic language related to Latvian and Old Prussian 
       with about 3.5 million speakers in Lithuania. There are also Lithuanian
@@ -11,7 +11,6 @@
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_lithuanian_LT.txt</train>
-<langcode>lt</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.luxembourgish.xml
+++ b/Data/alphabets/alphabet.luxembourgish.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="lb">
 <alphabet name="L&#x00EB;tzebuergesch / Luxembourgish with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_luxembourgish_LU.txt</train>
-<langcode>lb</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.macedonian.xml
+++ b/Data/alphabets/alphabet.macedonian.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="mk">
 <alphabet name="Macedonian / &#1052;&#1072;&#1082;&#1077;&#1076;&#1086;&#1085;&#1089;&#1082;&#1080; with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_macedonian_MK.txt</train>
-<langcode>mk</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.nepali.xml
+++ b/Data/alphabets/alphabet.nepali.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="ne">
 <alphabet name="Nepali with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_nepali_NP.txt</train>
-<langcode>ne</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.norwegian.xml
+++ b/Data/alphabets/alphabet.norwegian.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="no">
 <alphabet name="Norsk / Norwegian with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_norwegian_NO.txt</train>
-<langcode>no</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.occitan.xml
+++ b/Data/alphabets/alphabet.occitan.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="oc">
 <alphabet name="Occitan with punctuation and numerals">
 <!-- Occitan is a Romance language spoken mainly in southern France and also in Italy and Spain. There are perhaps 1.5 million people who speak Occitan in their daily lives, while 5 or 6 million people are able to speak the language. The majority of speakers are elderly and live in rural areas. There are six dialects of Occitan: Provencal, Gascon, Languedoc, Limousin, Alpine and Auvergne. -->
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_occitan_FR.txt</train>
-<langcode>oc</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.pashto.xml
+++ b/Data/alphabets/alphabet.pashto.xml
@@ -2,14 +2,13 @@
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet-nest.xsl"?>
 <!-- Author: David MacKay; NEEDS CHECKING BY AN EXPERT!  -->
-<alphabets>
+<alphabets langcode="ps">
 <alphabet name="Pashto (Nested groups) with punctuation and numerals">
 <!-- Pashto / &#1662;&#1690;&#1578;&#1608; -->
 <orientation type="RL"/>
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_pashto_AF.txt</train>
-<langcode>ps</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.persian.xml
+++ b/Data/alphabets/alphabet.persian.xml
@@ -2,13 +2,12 @@
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet-nest.xsl"?>
 <!-- Author: David MacKay and Behdad  -->
-<alphabets>
+<alphabets langcode="fa">
 <alphabet name="Persian (Nested groups) with punctuation and numerals">
 <orientation type="RL"/>
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_persian_IR.txt</train>
-<langcode>fa</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.polish.xml
+++ b/Data/alphabets/alphabet.polish.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="pl">
   <alphabet name="Polski / Polish">
     <!--Created by: Krzysiek grandysk@go2.pl-->
     <orientation type="LR" />
     <encoding type="CentralEurope" />
 
     <train>training_polish_PL.txt</train>
-    <langcode>pl</langcode>
     <palette>Default</palette>
 <paragraph d="&#182;" b="9"/>
 <space d="&#x25a1;" t=" " b="9" note="box" />

--- a/Data/alphabets/alphabet.portuguese.xml
+++ b/Data/alphabets/alphabet.portuguese.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="pt">
 <alphabet name="Portugu&#x00EA;s / Portuguese (Brazilian)">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <train>training_portuguese_BR.txt</train>
-<langcode>pt</langcode>
 <palette>Default</palette>
 <paragraph d="&#182;" b="9"/>
 <space d="&#x25a1;" t=" " b="9" note="box" />
@@ -153,7 +152,6 @@
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_portugueseC_BR.txt</train>
-<langcode>pt</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t=""/>
 <paragraph d="&#182;" b="9"/>

--- a/Data/alphabets/alphabet.romansch.xml
+++ b/Data/alphabets/alphabet.romansch.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="rm">
 <alphabet name="Rumantsch / Romansch with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_romansch_CH.txt</train>
-<langcode>rm</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.russian.xml
+++ b/Data/alphabets/alphabet.russian.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="ru">
 <alphabet name="Russian (&#1056;&#1091;&#1089;&#1089;&#1082;&#1080;&#1081;) - &#1050;&#1080;&#1088;&#1080;&#1083;&#1083;&#1080;&#1094;&#1072; alphabet">
 <orientation type="LR"/>
 <control d="Control" t=""/>
 <encoding type="Western"/>
 <train>training_russian_RU.txt</train>
-<langcode>ru</langcode>
 <paragraph d="&#182;" b="9"/>
 <space d="&#x25a1;" t=" " b="9"/>
 <control d="Control" t="" b="8"/>
@@ -139,7 +138,6 @@
 <control d="Control" t=""/>
 <encoding type="Western"/>
 <train>training_russianLatin_RU.txt</train>
-<langcode>ru</langcode>
 <paragraph d="&#182;" b="9"/>
 <space d="&#x25a1;" t=" " b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.sanskrit.xml
+++ b/Data/alphabets/alphabet.sanskrit.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="sa">
 <alphabet name="Sanskrit with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_sanskrit_IN.txt</train>
-<langcode>sa</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.serbian.xml
+++ b/Data/alphabets/alphabet.serbian.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="sr">
 <alphabet name="Serbian (&#1057;&#1088;&#1087;&#1089;&#1082;&#1080;) with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_serbian_YU.txt</train>
-<langcode>sr</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.spanish.xml
+++ b/Data/alphabets/alphabet.spanish.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="es">
 <alphabet name="Espa&#x00F1;ol / Spanish with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_spanish_ES.txt</train>
-<langcode>es</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>
@@ -144,7 +143,6 @@
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_spanishC_ES.txt</train>
-<langcode>es</langcode>
 <space d="&#x25a1;" t=" " b="9" note="box" />
 <control d="Control" t=""/>
 <paragraph d="&#182;" b="9"/>

--- a/Data/alphabets/alphabet.swedish.xml
+++ b/Data/alphabets/alphabet.swedish.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="sv">
 <alphabet name="Svenska / Swedish with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_swedish_SE.txt</train>
-<langcode>sv</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.ukrainian.xml
+++ b/Data/alphabets/alphabet.ukrainian.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="uk">
 <alphabet name="Ukrainian / &#1059;&#1082;&#1088;&#1072;&#1111;&#1085;&#1089;&#1100;&#1082;&#1072; with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>European/Asian</palette>
 <train>training_ukrainian_UA.txt</train>
-<langcode>uk</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Data/alphabets/alphabet.welsh.xml
+++ b/Data/alphabets/alphabet.welsh.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE alphabets SYSTEM "alphabet.dtd">
 <?xml-stylesheet type="text/xsl" href="alphabet.xsl"?>
-<alphabets>
+<alphabets langcode="cy">
 <alphabet name="Cymraeg / Welsh with punctuation and numerals">
 <orientation type="LR"/>
 <encoding type="Western"/>
 <palette>Default</palette>
 <train>training_welsh_GB.txt</train>
-<langcode>cy</langcode>
 <space d="&#x25a1;" t=" " b="9" />
 <paragraph d="&#182;" b="9"/>
 <control d="Control" t="" b="8"/>

--- a/Src/DasherCore/Alphabet/AlphIO.cpp
+++ b/Src/DasherCore/Alphabet/AlphIO.cpp
@@ -160,6 +160,15 @@ void CAlphIO::XmlStartHandler(const XML_Char *name, const XML_Char **atts) {
 
   CData = "";
 
+  if (strcmp(name, "alphabets") == 0) {
+    while(*atts != 0) {
+      if(strcmp(*atts, "langcode") == 0) {
+        DefaultLanguageCode = *(atts+1);
+      }
+      atts += 2;
+    }
+  }
+
   if(strcmp(name, "alphabet") == 0) {
     InputInfo = new CAlphInfo();
     InputInfo->Mutable = isUser();
@@ -363,6 +372,10 @@ void Reverse(SGroupInfo *&pList) {
 
 void CAlphIO::XmlEndHandler(const XML_Char *name) {
 
+  if (strcmp(name, "alphabets") == 0) {
+    DefaultLanguageCode = "";
+  }
+
   if(strcmp(name, "alphabet") == 0) {
     Reverse(InputInfo->pChild);
 
@@ -377,6 +390,10 @@ void CAlphIO::XmlEndHandler(const XML_Char *name) {
       InputInfo->m_vCharacters.push_back(*SpaceCharacter);
       InputInfo->iNumChildNodes++;
       delete SpaceCharacter;
+    }
+
+    if (InputInfo->LanguageCode.empty()) {
+      InputInfo->LanguageCode = DefaultLanguageCode;
     }
 
     InputInfo->iEnd = InputInfo->m_vCharacters.size()+1;

--- a/Src/DasherCore/Alphabet/AlphIO.h
+++ b/Src/DasherCore/Alphabet/AlphIO.h
@@ -77,6 +77,7 @@ private:
   std::string CData;            // Text gathered from when an elemnt starts to when it ends
   CAlphInfo *InputInfo;
   int iGroupIdx;
+  std::string DefaultLanguageCode;
 
   void XmlStartHandler(const XML_Char * name, const XML_Char ** atts);
   void XmlEndHandler(const XML_Char * name);


### PR DESCRIPTION
Adds `langcode` attribute on the `<alphabets>` element so that all alphabets in a file can share the same `langcode` instead of duplicating it into each.

Fixes #53.