### PR TITLE
Add ascii control files into packaging (#106)

### DIFF
--- a/Data/control/Makefile.am
+++ b/Data/control/Makefile.am
@@ -1,7 +1,11 @@
 dist_pkgdata_DATA = control.dtd \
 	control.xml \
 	control.411.xml \
+	control.all.txt.xml \
 	control.all.xml \
+	control.edit.txt.xml \
 	control.edit.xml \
+	control.speak.txt.xml \
 	control.speak.xml \
+	control.prepared_speech.txt.xml \
 	control.prepared_speech.xml


### PR DESCRIPTION
The control.*.txt.xml files referenced from settings.*.xml files are added. These are used when dasher started with "dasher --config <settings name>". Currently supported names are: edit, prepared_speech, and speak.